### PR TITLE
release version 1.0.0. support for SBT 1.0.0+.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@ Change Log
 
 All notable changes to this project will be documented in this file.
 
+1.0.0 - 2017-11-16
+------------------
+- Support for SBT 1.0.0+.
+
+#### Breaking change
+
+`.value` should be changed to `.evaluated` on the `testOnly` task in `build.sbt`:
+Before:
+```scala
+testOnly in Test := (testOnly in Test).dependsOn(startElasticMQ in Test).value
+```
+After:
+```scala
+testOnly in Test := (testOnly in Test).dependsOn(startElasticMQ in Test).evaluated
+```
+
 0.4.2 - 2017-02-23
 ---------------------
 - Enable different settings for different configurations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Fork, then clone the repo:
 
-    git clone git@github.com:your-username/sbt-dynamodb.git
+    git clone git@github.com:your-username/sbt-sqs.git
 
 Create a new branch for your work:
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Installation
 
 Add the following to your `project/plugins.sbt` file:
 ```
-addSbtPlugin("com.localytics" % "sbt-sqs" % "0.5.0")
+addSbtPlugin("com.localytics" % "sbt-sqs" % "1.0.0")
 ```
 
-sbt 1.0.0+ is supported by 0.5.0+ of this library.
+sbt 1.0.0+ is supported by 1.0.0+ of this library.
 
 if using sbt 0.13.6+ the recommended version of this library is 0.4.2.
 
-sbt 0.13.5 should work with the right bintray resolvers.
+sbt 0.13.5 should work with version 0.4.2 of this library and the right bintray resolvers.
 
 
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,19 @@ Support for running [ElasitcMQ](https://github.com/adamw/elasticmq) in tests.
 
 Installation
 ------------
+
 Add the following to your `project/plugins.sbt` file:
 ```
-addSbtPlugin("com.localytics" % "sbt-sqs" % "0.4.2")
+addSbtPlugin("com.localytics" % "sbt-sqs" % "0.5.0")
 ```
 
-sbt 0.13.6+ is supported. 0.13.5 should work with the right bintray resolvers.
+sbt 1.0.0+ is supported by 0.5.0+ of this library.
+
+if using sbt 0.13.6+ the recommended version of this library is 0.4.2.
+
+sbt 0.13.5 should work with the right bintray resolvers.
+
+
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To have ElasticMQ automatically start and stop around your tests
 ```
 startElasticMQ := startElasticMQ.dependsOn(compile in Test).value
 test in Test := (test in Test).dependsOn(startElasticMQ).value
-testOnly in Test := (testOnly in Test).dependsOn(startElasticMQ).value
+testOnly in Test := (testOnly in Test).dependsOn(startElasticMQ).evaluated
 testOptions in Test += elasticMQTestCleanup.value
 ```
 
@@ -111,7 +111,7 @@ Similarly, you can have the plugin automatically start and stop around your test
 ```
 startElasticMQ in Test := (startElasticMQ in Test).dependsOn(compile in Test).value
 test in Test := (test in Test).dependsOn(startElasticMQ in Test).value
-testOnly in Test := (testOnly in Test).dependsOn(startElasticMQ in Test).value
+testOnly in Test := (testOnly in Test).dependsOn(startElasticMQ in Test).evaluated
 testOptions in Test += (elasticMQTestCleanup in Test).value
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ description := "Support for running ElasticMQ in your integration tests"
 
 organization := "com.localytics"
 
+scalaVersion := "2.12.4"
+
 // Sane set of compiler flags
 scalacOptions ++= Seq(
   "-deprecation",         // Emit warning and location for usages of deprecated APIs
@@ -17,11 +19,11 @@ scalacOptions ++= Seq(
 )
 
 // This is an auto plugin
-// http://www.scala-sbt.org/0.13/docs/Plugins.html#Creating+an+auto+plugin
+// http://www.scala-sbt.org/1.x/docs/Plugins.html#Creating+an+auto+plugin
 sbtPlugin := true
 
 // Generate a POM
-// http://www.scala-sbt.org/0.13/docs/Publishing.html#Modifying+the+generated+POM
+// http://www.scala-sbt.org/1.x/docs/Publishing.html#Modifying+the+generated+POM
 publishMavenStyle := false
 
 // MIT License for bintray
@@ -37,11 +39,16 @@ bintrayOrganization := Some("localytics")
 bintrayPackageLabels := Seq("localytics", "sbt", "aws", "sqs", "elasticmq", "test", "testing")
 
 // Error on conflicting dependencies
-// http://www.scala-sbt.org/0.13/docs/Library-Management.html#Conflict+Management
+// http://www.scala-sbt.org/1.x/docs/Library-Management.html#Conflict+Management
 conflictManager := ConflictManager.strict
 
 // Error on circular dependencies
-// http://www.scala-sbt.org/0.13/docs/sbt-0.13-Tech-Previews.html#Circular+dependency
+// http://www.scala-sbt.org/1.x/docs/sbt-0.13-Tech-Previews.html#Circular+dependency
 updateOptions := updateOptions.value.withCircularDependencyLevel(CircularDependencyLevel.Error)
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+libraryDependencies +=
+  ( "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+    // Scalatest 3.0.1 is slightly behind sbt and Scala dependencies for these two modules, so they must be excluded
+    // while Strict dependency checking is enabled.
+    exclude("org.scala-lang.modules", s"scala-xml_${scalaBinaryVersion.value}")
+    exclude("org.scala-lang.modules", s"scala-parser-combinators_${scalaBinaryVersion.value}") )

--- a/build.sbt
+++ b/build.sbt
@@ -47,8 +47,8 @@ conflictManager := ConflictManager.strict
 updateOptions := updateOptions.value.withCircularDependencyLevel(CircularDependencyLevel.Error)
 
 libraryDependencies +=
-  ( "org.scalatest" %% "scalatest" % "3.0.1" % "test"
-    // Scalatest 3.0.1 is slightly behind sbt and Scala dependencies for these two modules, so they must be excluded
-    // while Strict dependency checking is enabled.
+  ( "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+    // Scalatest 3.0.4 is slightly behind sbt and Scala dependencies for these two modules, so they must be excluded
+    // while Strict dependency checking is enabled. Once 3.1.x is released this will likely be resolved.
     exclude("org.scala-lang.modules", s"scala-xml_${scalaBinaryVersion.value}")
     exclude("org.scala-lang.modules", s"scala-parser-combinators_${scalaBinaryVersion.value}") )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.0.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")

--- a/src/main/scala/com/localytics/sbt/sqs/ElasticMQKeys.scala
+++ b/src/main/scala/com/localytics/sbt/sqs/ElasticMQKeys.scala
@@ -28,7 +28,7 @@ object ElasticMQKeys {
 
   lazy val baseElasticMQSettings = Seq(
 
-    elasticMQVersion        := "0.9.3",
+    elasticMQVersion        := "0.13.8",
     elasticMQDir            := file("elastic-mq"),
     elasticMQUrl            := s"https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-${elasticMQVersion.value}.jar",
     elasticMQFileName       := s"elasticmq-server-${elasticMQVersion.value}.jar",
@@ -41,7 +41,10 @@ object ElasticMQKeys {
     downloadElasticMQ       := DownloadElasticMQ(elasticMQVersion.value, elasticMQUrl.value, elasticMQDir.value, elasticMQFileName.value, streams.value),
     startElasticMQ          := StartElasticMQ(elasticMQDir.value, elasticMQFileName.value, elasticMQHeapSize.value, nodeAddressConf.value, restSQSConf.value, queuesConf.value, streams.value),
     stopElasticMQ           := StopElasticMQ(streams.value),
-    elasticMQTestCleanup    := Tests.Cleanup(() => StopElasticMQ(streams.value)),
+    elasticMQTestCleanup    := {
+      val streamsValue = streams.value
+      Tests.Cleanup(() => StopElasticMQ(streamsValue))
+    },
     startElasticMQ          := startElasticMQ.dependsOn(downloadElasticMQ).value
   )
 }

--- a/src/main/scala/com/localytics/sbt/sqs/StartElasticMQ.scala
+++ b/src/main/scala/com/localytics/sbt/sqs/StartElasticMQ.scala
@@ -4,8 +4,8 @@ import java.io.File
 
 import com.localytics.sbt.sqs.ElasticMQKeys._
 import sbt.Keys._
-import sbt._
 
+import scala.sys.process._
 import scala.util.Try
 
 object StartElasticMQ {

--- a/src/main/scala/com/localytics/sbt/sqs/StopElasticMQ.scala
+++ b/src/main/scala/com/localytics/sbt/sqs/StopElasticMQ.scala
@@ -1,6 +1,8 @@
 package com.localytics.sbt.sqs
 
-import sbt._
+import sbt.Keys
+
+import scala.sys.process._
 
 object StopElasticMQ {
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.0"
+version in ThisBuild := "1.0.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.3-SNAPSHOT"
+version in ThisBuild := "1.0.0"


### PR DESCRIPTION
this will be version 1.0.0

bumps dependency versions and fixes incompatablities in order to be used with SBT 1.0.0+

tested locally with `sbt publishLocal`