### PR TITLE
0.5.0 adding dead letter

### DIFF
--- a/src/main/scala/com/localytics/sbt/sqs/ElasticMQKeys.scala
+++ b/src/main/scala/com/localytics/sbt/sqs/ElasticMQKeys.scala
@@ -7,7 +7,8 @@ import sbt._
 
 object ElasticMQKeys {
 
-  case class QueueConf(name: String, visibilityTimeoutSecs: Int = 10, delaySecs: Int = 5, receiveMessageWaitSecs: Int = 0)
+  case class DLQConf(name: String, maxReceiveCount: Int)
+  case class QueueConf(name: String, visibilityTimeoutSecs: Int = 10, delaySecs: Int = 5, receiveMessageWaitSecs: Int = 0, deadLettersQueue: Option[DLQConf] = None)
   case class NodeAddressConf(protocol: String = "http", host: String = "localhost", port: Int = 9324, contextPath: String = "")
   case class RestSQSConf(enabled: Boolean = true, bindPort: Int = 9324, bindHostname: String = "0.0.0.0", sqsLimits: String = "strict")
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.2"
+version in ThisBuild := "0.5.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.2"
+version in ThisBuild := "0.5.0"


### PR DESCRIPTION
This addresses #11 
I see that support was added to create Queues on start-up from sbt-sqs recently.  That is terrific.  However, it does not support dead letter queues (dlq) which we need to have so we can test failure cases of acking (deleteMessage).  This PR is aimed at fixing that.

In addition, this change is against 0.4.2.  Hence the version number being 0.5.0.  We need a release of 0.5.0 as we can't upgrade our dependencies yet to sbt 1.0.1.  *So I am absolutely positive you will want to change the base branch via creating a branch from the tag 0.4.2*.  Assuming you are ok with this change I am more than happy once accepted to work on a PR for the 1.0.0 which should be a rather simple cherry-pick.

